### PR TITLE
less/_mixin.lessのベンダープレフィックスの修正

### DIFF
--- a/boilerplate/less/_mixin.less
+++ b/boilerplate/less/_mixin.less
@@ -18,20 +18,14 @@
 }
 
 .box-shadow (@x: 0, @y: 0, @blur: 25px, @color: rgba(0,0,0,.20)) {
-    -moz-box-shadow: @x @y @blur @color;
-    -webkit-box-shadow: @x @y @blur @color;
     box-shadow: @x @y @blur @color;
 }
 
 .box-shadow-inset (@x: 0, @y: 0, @blur: 25px, @color: rgba(0,0,0,.20)) {
-    -moz-box-shadow: inset @x @y @blur @color;
-    -webkit-box-shadow: inset @x @y @blur @color;
     box-shadow: inset @x @y @blur @color;
 }
 
 .text-shadow (@x: 0, @y: 0, @blur: 5px, @color: rgba(0,0,0,.20)) {
-    -moz-text-shadow: @x @y @blur @color;
-    -webkit-text-shadow: @x @y @blur @color;
     text-shadow: @x @y @blur @color;
 }
 


### PR DESCRIPTION
box-shadow及びtext-shadowが最新バージョンのブラウザに対応したため削除
