### PR TITLE
opacityのベンダープレフィックスの削除

### DIFF
--- a/boilerplate/less/_mixin.less
+++ b/boilerplate/less/_mixin.less
@@ -50,9 +50,6 @@
 }
 
 .opacity(@opacity: 0.25) {
-    -moz-opacity: @opacity;
-    -khtml-opacity: @opacity;
-    -webkit-opacity: @opacity;
     opacity: @opacity;
 }
 


### PR DESCRIPTION
opacityのサポートが最新ブラウザで対応したため削除
…というようなプルリクエストをしばらく送ると思います
